### PR TITLE
chore: Update soroban-sdk dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = [
 ]
 
 [workspace.dependencies]
-soroban-sdk = "21.0.1-preview.3"
-soroban-token-sdk = "21.0.1-preview.3"
+soroban-sdk = "21.1.0-rc.1"
+soroban-token-sdk = "21.1.0-rc.1"
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
### Summary

- This pull request updates the soroban-sdk dependency after Stellar has updated the network to protocol 21. 

### Details

- Update soroban-sdk

### Reference

- [Protocol 21 Upgrade Guide](https://stellar.org/blog/developers/protocol-21-upgrade-guide)
