### PR TITLE
feat: Add enable/disable lender in contract storage

### DIFF
--- a/contracts/liquidity-pool/src/errors.rs
+++ b/contracts/liquidity-pool/src/errors.rs
@@ -18,4 +18,5 @@ pub enum LPError {
     TokenNotFound = 12,
     LenderNotFoundInContributions = 13,
     LenderBalanceNotFound = 14,
+    LenderNotFound = 15,
 }

--- a/contracts/liquidity-pool/src/storage.rs
+++ b/contracts/liquidity-pool/src/storage.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{Address, Env, Vec};
 
 use crate::{
     errors::LPError,
-    types::{DataKey, Loan},
+    types::{DataKey, Lender, Loan},
 };
 
 pub fn check_admin(env: &Env) -> Result<Address, LPError> {
@@ -55,11 +55,11 @@ pub fn read_loans(env: &Env, borrower: &Address) -> Vec<Loan> {
         .unwrap_or(Vec::new(env))
 }
 
-pub fn read_lender(env: &Env, lender: &Address) -> i128 {
+pub fn read_lender(env: &Env, lender: &Address) -> Result<Lender, LPError> {
     env.storage()
         .persistent()
         .get(&DataKey::Lender(lender.clone()))
-        .unwrap_or(0)
+        .ok_or(LPError::LenderNotFound)
 }
 
 pub fn read_token(env: &Env) -> Result<Address, LPError> {
@@ -117,10 +117,10 @@ pub fn write_loans(env: &Env, borrower: &Address, loans: &Vec<Loan>) {
         .set(&DataKey::Loan(borrower.clone()), loans);
 }
 
-pub fn write_lender(env: &Env, lender: &Address, amount: &i128) {
+pub fn write_lender(env: &Env, lender: &Address, data: &Lender) {
     env.storage()
         .persistent()
-        .set(&DataKey::Lender(lender.clone()), amount);
+        .set(&DataKey::Lender(lender.clone()), data);
 }
 
 pub fn write_lender_contribution(env: &Env, contributions: Vec<Address>) {

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -74,7 +74,7 @@ fn test_balance_with_lender() {
 
     let balance = setup.liquid_contract.client().balance(&lender);
 
-    assert_eq!(setup.liquid_contract.read_lender(&lender), balance);
+    assert_eq!(setup.liquid_contract.read_lender(&lender), Ok(balance));
 }
 
 #[test]
@@ -126,10 +126,10 @@ fn test_deposit() {
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 11i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 4i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(4i128));
     assert!(setup.liquid_contract.is_lender_in_contributions(&lender1));
 
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 7i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(7i128));
     assert!(setup.liquid_contract.is_lender_in_contributions(&lender2));
     assert_eq!(
         contract_events,
@@ -275,8 +275,8 @@ fn test_withdraw() {
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 8i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 5i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 3i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(5i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(3i128));
     assert!(setup.liquid_contract.is_lender_in_contributions(&lender1));
     assert!(setup.liquid_contract.is_lender_in_contributions(&lender2));
     assert_eq!(
@@ -386,7 +386,7 @@ fn test_withdraw_by_remove_contribution() {
         .withdraw(&lender, &10i128);
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 0i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender), 0i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender), Ok(0i128));
     assert!(!setup.liquid_contract.is_lender_in_contributions(&lender));
 }
 
@@ -513,8 +513,8 @@ fn test_loan() {
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 10i128);
     assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 5i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 5i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(5i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(5i128));
     assert_eq!(
         contract_events,
         vec![
@@ -791,8 +791,8 @@ fn test_repay_loan_with_repayment_total_amount() {
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 0i128);
     assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 0i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 0i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(0i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(0i128));
 
     set_timestamp_for_20_days(&setup.env);
 
@@ -810,8 +810,8 @@ fn test_repay_loan_with_repayment_total_amount() {
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 1002i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 501i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 501i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(501i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(501i128));
     assert!(!setup.liquid_contract.has_loan(&borrower, loan_id));
     assert_eq!(
         contract_events,
@@ -953,8 +953,8 @@ fn test_repay_loan_without_repayment_total_amount() {
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 0i128);
     assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 0i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 0i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(0i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(0i128));
 
     set_timestamp_for_20_days(&setup.env);
 
@@ -972,8 +972,8 @@ fn test_repay_loan_without_repayment_total_amount() {
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 1000i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 500i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 500i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(500i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(500i128));
     assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
     assert_eq!(
         setup.liquid_contract.read_loan_amount(&borrower, loan_id),

--- a/contracts/liquidity-pool/src/testutils.rs
+++ b/contracts/liquidity-pool/src/testutils.rs
@@ -157,9 +157,11 @@ impl LiquidityPoolContract {
         })
     }
 
-    pub fn read_lender(&self, lender: &Address) -> i128 {
-        self.env
-            .as_contract(&self.contract_id, || read_lender(&self.env, lender))
+    pub fn read_lender(&self, lender: &Address) -> Result<i128, LPError> {
+        self.env.as_contract(&self.contract_id, || {
+            let lender = read_lender(&self.env, lender)?;
+            Ok(lender.balance)
+        })
     }
 
     pub fn is_lender_in_contributions(&self, lender: &Address) -> bool {

--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -11,6 +11,13 @@ pub struct Loan {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct Lender {
+    pub active: bool,
+    pub balance: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub enum DataKey {
     TotalBalance,
     Token,


### PR DESCRIPTION
### Summary

This pull request modifies the storage of lenders in the contract. Previously, we only stored their amount, now we add the ability to enable/disable it. 

### Details

- This change is to be able to add the new functionality proposed by the client. You want the admin to be able to enable/disable a lender to deposit or participate in loan contributions without having to remove it from the contract.
