### PR TITLE
feat: Add function for enable/disable a lender 

### DIFF
--- a/contracts/liquidity-pool/src/errors.rs
+++ b/contracts/liquidity-pool/src/errors.rs
@@ -19,4 +19,5 @@ pub enum LPError {
     LenderNotFoundInContributions = 13,
     LenderBalanceNotFound = 14,
     LenderNotFound = 15,
+    LenderDisabled = 16,
 }

--- a/contracts/liquidity-pool/src/event.rs
+++ b/contracts/liquidity-pool/src/event.rs
@@ -40,6 +40,11 @@ pub(crate) fn add_lender(env: &Env, admin: Address, lender: Address) {
     env.events().publish(topics, ());
 }
 
+pub(crate) fn set_lender_status(env: &Env, admin: Address, lender: Address, active: bool) {
+    let topics = (Symbol::new(env, "set_lender_status"), admin, lender);
+    env.events().publish(topics, active);
+}
+
 pub(crate) fn remove_lender(env: &Env, admin: Address, lender: Address) {
     let topics = (Symbol::new(env, "remove_lender"), admin, lender);
     env.events().publish(topics, ());

--- a/contracts/liquidity-pool/src/interface.rs
+++ b/contracts/liquidity-pool/src/interface.rs
@@ -18,6 +18,8 @@ pub trait LiquidityPoolTrait {
 
     fn add_lender(env: Env, lender: Address) -> Result<(), LPError>;
 
+    fn set_lender_status(env: Env, lender: Address, active: bool) -> Result<(), LPError>;
+
     fn remove_lender(env: Env, lender: Address) -> Result<(), LPError>;
 
     fn add_borrower(env: Env, borrower: Address) -> Result<(), LPError>;

--- a/contracts/liquidity-pool/src/percentage.rs
+++ b/contracts/liquidity-pool/src/percentage.rs
@@ -36,11 +36,14 @@ pub fn process_lender_contribution(
 
     for address in contributions.iter() {
         let lender = read_lender(env, &address)?;
-        let percentage = calculate_percentage(&lender.balance, total_balance);
-        let new_lender_amount =
-            calculate_new_lender_amount(loan_amount, &lender.balance, percentage);
-        lender_contributions.set(address.clone(), percentage);
-        new_lender_amounts.set(address.clone(), new_lender_amount);
+
+        if lender.active {
+            let percentage = calculate_percentage(&lender.balance, total_balance);
+            let new_lender_amount =
+                calculate_new_lender_amount(loan_amount, &lender.balance, percentage);
+            lender_contributions.set(address.clone(), percentage);
+            new_lender_amounts.set(address.clone(), new_lender_amount);
+        }
     }
     Ok((lender_contributions, new_lender_amounts))
 }

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -220,6 +220,23 @@ fn test_deposit_with_negative_amount() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #16)")]
+fn test_deposit_with_disabled_lender() {
+    let setup = Setup::new();
+    setup.env.mock_all_auths();
+    let lender = Address::generate(&setup.env);
+
+    setup.liquid_contract.client().add_lender(&lender);
+
+    setup
+        .liquid_contract
+        .client()
+        .set_lender_status(&lender, &false);
+
+    setup.liquid_contract.client().deposit(&lender, &10i128);
+}
+
+#[test]
 fn test_withdraw() {
     let setup = Setup::new();
     let lender1 = Address::generate(&setup.env);
@@ -783,8 +800,8 @@ fn test_repay_loan_with_repayment_total_amount() {
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 10020i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 5009i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 5009i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(5009i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(5009i128));
     assert!(!setup.liquid_contract.has_loan(&borrower, loan_id));
     assert_eq!(
         contract_events,
@@ -1566,4 +1583,72 @@ fn test_remove_without_lender() {
         .client()
         .mock_all_auths()
         .remove_lender(&lender);
+}
+
+#[test]
+fn test_set_lender_status() {
+    let setup = Setup::new();
+    setup.env.mock_all_auths();
+    let lender = Address::generate(&setup.env);
+
+    setup.liquid_contract.client().add_lender(&lender);
+    assert!(setup.liquid_contract.has_lender(&lender));
+
+    setup
+        .liquid_contract
+        .client()
+        .set_lender_status(&lender, &false);
+
+    assert_eq!(setup.liquid_contract.read_lender_status(&lender), Ok(false));
+    let contract_events = setup.liquid_contract.get_contract_events();
+
+    assert_eq!(
+        contract_events,
+        vec![
+            &setup.env,
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "initialize").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    setup.token.address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "add_lender").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    lender.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "set_lender_status").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    lender.into_val(&setup.env),
+                ],
+                (false).into_val(&setup.env)
+            )
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #10)")]
+fn test_set_lender_status_not_registered() {
+    let setup = Setup::new();
+    let lender = Address::generate(&setup.env);
+
+    setup
+        .liquid_contract
+        .client()
+        .mock_all_auths()
+        .set_lender_status(&lender, &false);
 }

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -1652,3 +1652,33 @@ fn test_set_lender_status_not_registered() {
         .mock_all_auths()
         .set_lender_status(&lender, &false);
 }
+
+#[test]
+#[should_panic(expected = "Unauthorized function call for address")]
+fn test_set_lender_status_with_fake_admin() {
+    let setup = Setup::new();
+    let lender = Address::generate(&setup.env);
+    let fake_admin = Address::generate(&setup.env);
+
+    setup
+        .liquid_contract
+        .client()
+        .mock_all_auths()
+        .add_lender(&lender);
+
+    assert!(setup.liquid_contract.has_lender(&lender));
+
+    setup
+        .liquid_contract
+        .client()
+        .mock_auths(&[MockAuth {
+            address: &fake_admin,
+            invoke: &MockAuthInvoke {
+                contract: &setup.liquid_contract_id,
+                fn_name: "set_lender_status",
+                args: (lender.clone(), false).into_val(&setup.env),
+                sub_invokes: &[],
+            },
+        }])
+        .set_lender_status(&lender, &false);
+}

--- a/contracts/liquidity-pool/src/testutils.rs
+++ b/contracts/liquidity-pool/src/testutils.rs
@@ -164,6 +164,13 @@ impl LiquidityPoolContract {
         })
     }
 
+    pub fn read_lender_status(&self, lender: &Address) -> Result<bool, LPError> {
+        self.env.as_contract(&self.contract_id, || {
+            let lender = read_lender(&self.env, lender)?;
+            Ok(lender.active)
+        })
+    }
+
     pub fn is_lender_in_contributions(&self, lender: &Address) -> bool {
         self.env.as_contract(&self.contract_id, || {
             let contributions = read_contributions(&self.env);


### PR DESCRIPTION
### Summary

This pull request adds a function to enable/disable lenders in the contract. The function is exclusive to the admin and disables the lender from being able to contribute to a loan or deposit money to the contract.

### Details

- We created a single function for handling enable/disable lenders to compress the functionality and then split it when creating an API since the only value that is modified is whether it is active or not,
- The function only checks if it is enabled or not to add or remove it from the contributions to the loan.

