### PR TITLE
feat: Add function to enable/disable borrowers

### DIFF
--- a/contracts/liquidity-pool/src/errors.rs
+++ b/contracts/liquidity-pool/src/errors.rs
@@ -19,4 +19,6 @@ pub enum LPError {
     LenderNotFoundInContributions = 13,
     LenderBalanceNotFound = 14,
     LenderNotFound = 15,
+    BorrowerNotFound = 17,
+    BorrowerDisabled = 18,
 }

--- a/contracts/liquidity-pool/src/event.rs
+++ b/contracts/liquidity-pool/src/event.rs
@@ -30,6 +30,12 @@ pub(crate) fn add_borrower(env: &Env, admin: Address, borrower: Address) {
     env.events().publish(topics, ());
 }
 
+pub(crate) fn set_borrower_status(env: &Env, admin: Address, borrower: Address, active: bool) {
+    let topics: (Symbol, Address, Address) =
+        (Symbol::new(env, "set_borrower_status"), admin, borrower);
+    env.events().publish(topics, active);
+}
+
 pub(crate) fn remove_borrower(env: &Env, admin: Address, borrower: Address) {
     let topics = (Symbol::new(env, "remove_borrower"), admin, borrower);
     env.events().publish(topics, ());

--- a/contracts/liquidity-pool/src/interface.rs
+++ b/contracts/liquidity-pool/src/interface.rs
@@ -22,5 +22,7 @@ pub trait LiquidityPoolTrait {
 
     fn add_borrower(env: Env, borrower: Address) -> Result<(), LPError>;
 
+    fn set_borrower_status(env: Env, borrower: Address, active: bool) -> Result<(), LPError>;
+
     fn remove_borrower(env: Env, lender: Address) -> Result<(), LPError>;
 }

--- a/contracts/liquidity-pool/src/storage.rs
+++ b/contracts/liquidity-pool/src/storage.rs
@@ -34,6 +34,13 @@ pub fn has_lender(env: &Env, lender: &Address) -> bool {
         .has(&DataKey::Lender(lender.clone()))
 }
 
+pub fn read_borrower(env: &Env, borrower: &Address) -> Result<bool, LPError> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Borrower(borrower.clone()))
+        .ok_or(LPError::BorrowerNotFound)
+}
+
 pub fn read_contract_balance(env: &Env) -> i128 {
     env.storage()
         .persistent()

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -624,6 +624,23 @@ fn test_loan_without_borrower() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #18)")]
+fn test_loan_with_disable_borrower() {
+    let setup = Setup::new();
+    setup.env.mock_all_auths();
+    let borrower = Address::generate(&setup.env);
+
+    setup.liquid_contract.client().add_borrower(&borrower);
+
+    setup
+        .liquid_contract
+        .client()
+        .set_borrower_status(&borrower, &false);
+
+    setup.liquid_contract.client().loan(&borrower, &10i128);
+}
+
+#[test]
 fn test_request_two_loans() {
     let setup = Setup::new();
     let borrower = Address::generate(&setup.env);
@@ -783,8 +800,8 @@ fn test_repay_loan_with_repayment_total_amount() {
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(setup.liquid_contract.read_contract_balance(), 10020i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender1), 5009i128);
-    assert_eq!(setup.liquid_contract.read_lender(&lender2), 5009i128);
+    assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(5009i128));
+    assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(5009i128));
     assert!(!setup.liquid_contract.has_loan(&borrower, loan_id));
     assert_eq!(
         contract_events,
@@ -1251,6 +1268,105 @@ fn test_add_registered_borrower() {
         .client()
         .mock_all_auths()
         .add_borrower(&borrower);
+}
+
+#[test]
+fn test_set_borrower_status() {
+    let setup = Setup::new();
+    setup.env.mock_all_auths();
+    let borrower = Address::generate(&setup.env);
+
+    setup.liquid_contract.client().add_borrower(&borrower);
+
+    assert!(setup.liquid_contract.has_borrower(&borrower));
+
+    setup
+        .liquid_contract
+        .client()
+        .set_borrower_status(&borrower, &false);
+
+    let contract_events = setup.liquid_contract.get_contract_events();
+
+    assert_eq!(setup.liquid_contract.read_borrower(&borrower), Ok(false));
+    assert_eq!(
+        contract_events,
+        vec![
+            &setup.env,
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "initialize").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    setup.token.address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "add_borrower").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    borrower.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "set_borrower_status").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    borrower.into_val(&setup.env),
+                ],
+                (false).into_val(&setup.env)
+            )
+        ]
+    );
+}
+
+#[test]
+#[should_panic(expected = "Unauthorized function call for address")]
+fn test_set_borrower_status_with_fake_admin() {
+    let setup = Setup::new();
+    let borrower = Address::generate(&setup.env);
+    let fake_admin = Address::generate(&setup.env);
+
+    setup
+        .liquid_contract
+        .client()
+        .mock_all_auths()
+        .add_borrower(&borrower);
+
+    assert!(setup.liquid_contract.has_borrower(&borrower));
+
+    setup
+        .liquid_contract
+        .client()
+        .mock_auths(&[MockAuth {
+            address: &fake_admin,
+            invoke: &MockAuthInvoke {
+                contract: &setup.liquid_contract_id,
+                fn_name: "set_borrower_status",
+                args: (borrower.clone(), false).into_val(&setup.env),
+                sub_invokes: &[],
+            },
+        }])
+        .set_borrower_status(&borrower, &false);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_set_borrower_status_without_borrower() {
+    let setup = Setup::new();
+    let borrower = Address::generate(&setup.env);
+
+    setup
+        .liquid_contract
+        .client()
+        .mock_all_auths()
+        .set_borrower_status(&borrower, &false);
 }
 
 #[test]

--- a/contracts/liquidity-pool/src/testutils.rs
+++ b/contracts/liquidity-pool/src/testutils.rs
@@ -2,8 +2,8 @@
 
 use crate::errors::LPError;
 use crate::storage::{
-    has_borrower, has_lender, read_admin, read_contract_balance, read_contributions, read_lender,
-    read_loans, read_token,
+    has_borrower, has_lender, read_admin, read_borrower, read_contract_balance, read_contributions,
+    read_lender, read_loans, read_token,
 };
 use crate::LiquidityPoolContractClient;
 use soroban_sdk::{
@@ -140,6 +140,13 @@ impl LiquidityPoolContract {
         self.env.as_contract(&self.contract_id, || {
             let token = read_token(&self.env)?;
             Ok(token)
+        })
+    }
+
+    pub fn read_borrower(&self, borrower: &Address) -> Result<bool, LPError> {
+        self.env.as_contract(&self.contract_id, || {
+            let borrower = read_borrower(&self.env, borrower)?;
+            Ok(borrower)
         })
     }
 


### PR DESCRIPTION
### Summary

This pull request add enable/disable a borrower. It is a function exclusive to the admin. It prevents them from being able to continue borrowing if they are not enabled.

### Details

- A function is created to allow the admin to enable/disable borrowers without having to remove them from the contract. 
- If they are disabled, they will no longer be able to borrow from the contract but they can still pay their outstanding loans.


