### PR TITLE
feat: Add min and max amounts for storage of borrowers

### DIFF
--- a/contracts/liquidity-pool/src/storage.rs
+++ b/contracts/liquidity-pool/src/storage.rs
@@ -2,7 +2,7 @@ use soroban_sdk::{Address, Env, Vec};
 
 use crate::{
     errors::LPError,
-    types::{DataKey, Lender, Loan},
+    types::{Borrower, DataKey, Lender, Loan},
 };
 
 pub fn check_admin(env: &Env) -> Result<Address, LPError> {
@@ -34,7 +34,7 @@ pub fn has_lender(env: &Env, lender: &Address) -> bool {
         .has(&DataKey::Lender(lender.clone()))
 }
 
-pub fn read_borrower(env: &Env, borrower: &Address) -> Result<bool, LPError> {
+pub fn read_borrower(env: &Env, borrower: &Address) -> Result<Borrower, LPError> {
     env.storage()
         .persistent()
         .get(&DataKey::Borrower(borrower.clone()))
@@ -106,10 +106,10 @@ pub fn write_admin(env: &Env, admin: &Address) {
     env.storage().persistent().set(&DataKey::Admin, admin);
 }
 
-pub fn write_borrower(env: &Env, borrower: &Address, is_loaned: bool) {
+pub fn write_borrower(env: &Env, borrower: &Address, data: Borrower) {
     env.storage()
         .persistent()
-        .set(&DataKey::Borrower(borrower.clone()), &is_loaned);
+        .set(&DataKey::Borrower(borrower.clone()), &data);
 }
 
 pub fn write_contract_balance(env: &Env, amount: &i128) {

--- a/contracts/liquidity-pool/src/storage.rs
+++ b/contracts/liquidity-pool/src/storage.rs
@@ -106,10 +106,10 @@ pub fn write_admin(env: &Env, admin: &Address) {
     env.storage().persistent().set(&DataKey::Admin, admin);
 }
 
-pub fn write_borrower(env: &Env, borrower: &Address, data: Borrower) {
+pub fn write_borrower(env: &Env, address: &Address, borrower: Borrower) {
     env.storage()
         .persistent()
-        .set(&DataKey::Borrower(borrower.clone()), &data);
+        .set(&DataKey::Borrower(address.clone()), &borrower);
 }
 
 pub fn write_contract_balance(env: &Env, amount: &i128) {

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -1303,8 +1303,9 @@ fn test_set_borrower_status() {
         .set_borrower_status(&borrower, &false);
 
     let contract_events = setup.liquid_contract.get_contract_events();
+    let store_borrower = setup.liquid_contract.read_borrower(&borrower).unwrap();
 
-    assert_eq!(setup.liquid_contract.read_borrower(&borrower), Ok(false));
+    assert!(!store_borrower.active);
     assert_eq!(
         contract_events,
         vec![

--- a/contracts/liquidity-pool/src/testutils.rs
+++ b/contracts/liquidity-pool/src/testutils.rs
@@ -5,6 +5,7 @@ use crate::storage::{
     has_borrower, has_lender, read_admin, read_borrower, read_contract_balance, read_contributions,
     read_lender, read_loans, read_token,
 };
+use crate::types::Borrower;
 use crate::LiquidityPoolContractClient;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -143,7 +144,7 @@ impl LiquidityPoolContract {
         })
     }
 
-    pub fn read_borrower(&self, borrower: &Address) -> Result<bool, LPError> {
+    pub fn read_borrower(&self, borrower: &Address) -> Result<Borrower, LPError> {
         self.env.as_contract(&self.contract_id, || {
             let borrower = read_borrower(&self.env, borrower)?;
             Ok(borrower)

--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -18,6 +18,14 @@ pub struct Lender {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct Borrower {
+    pub active: bool,
+    pub min_withdraw: i128,
+    pub max_withdraw: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub enum DataKey {
     TotalBalance,
     Token,


### PR DESCRIPTION
### Summary

This pull request adds the minimum and maximum amounts to the borrowers' storage.

### Details

- The functions for storing borrowers are corrected.
- By default when creating a borrower the minimum amount is set to 0 and the maximum amount to 10000

