### PR TITLE
ci: Remove Rust beta channel in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - beta
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Summary

This pull request removes the Rust beta channel to run the tests. This change is because soroban-sdk and the beta channel were updated at the same time and give errors in the authentication tests.

