### PR TITLE
feat: Change lender's storage by add active loans and their status

### DIFF
--- a/contracts/liquidity-pool/src/event.rs
+++ b/contracts/liquidity-pool/src/event.rs
@@ -1,4 +1,13 @@
+use crate::types::LenderStatus;
 use soroban_sdk::{Address, Env, Symbol};
+
+pub fn lender_status_to_string(status: LenderStatus) -> &'static str {
+    match status {
+        LenderStatus::Enabled => "enabled",
+        LenderStatus::Disabled => "disabled",
+        LenderStatus::PendingRemoval => "pending_removal",
+    }
+}
 
 pub(crate) fn initialize(env: &Env, admin: Address, token: Address) {
     let topics = (Symbol::new(env, "initialize"), admin, token);
@@ -46,9 +55,10 @@ pub(crate) fn add_lender(env: &Env, admin: Address, lender: Address) {
     env.events().publish(topics, ());
 }
 
-pub(crate) fn set_lender_status(env: &Env, admin: Address, lender: Address, active: bool) {
+pub(crate) fn set_lender_status(env: &Env, admin: Address, lender: Address, status: LenderStatus) {
     let topics = (Symbol::new(env, "set_lender_status"), admin, lender);
-    env.events().publish(topics, active);
+    env.events()
+        .publish(topics, lender_status_to_string(status));
 }
 
 pub(crate) fn remove_lender(env: &Env, admin: Address, lender: Address) {

--- a/contracts/liquidity-pool/src/percentage.rs
+++ b/contracts/liquidity-pool/src/percentage.rs
@@ -2,6 +2,7 @@ use soroban_sdk::{Address, Env, Map, Vec};
 
 use crate::errors::LPError;
 use crate::storage::read_lender;
+use crate::types::LenderStatus;
 
 type ContributionsMap = Map<Address, i64>;
 type LenderAmountMap = Map<Address, i128>;
@@ -37,7 +38,7 @@ pub fn process_lender_contribution(
     for address in contributions.iter() {
         let lender = read_lender(env, &address)?;
 
-        if lender.active {
+        if lender.status == LenderStatus::Enabled {
             let percentage = calculate_percentage(&lender.balance, total_balance);
             let new_lender_amount =
                 calculate_new_lender_amount(loan_amount, &lender.balance, percentage);

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -2,6 +2,7 @@
 extern crate std;
 
 use super::testutils::{create_token_contract, set_timestamp_for_20_days, Setup};
+use crate::types::LenderStatus;
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
     vec, Address, Env, IntoVal, Symbol,
@@ -1715,7 +1716,10 @@ fn test_set_lender_status() {
         .client()
         .set_lender_status(&lender, &false);
 
-    assert_eq!(setup.liquid_contract.read_lender_status(&lender), Ok(false));
+    assert_eq!(
+        setup.liquid_contract.read_lender_status(&lender),
+        Ok(LenderStatus::Disabled)
+    );
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(
@@ -1750,7 +1754,7 @@ fn test_set_lender_status() {
                     setup.admin.into_val(&setup.env),
                     lender.into_val(&setup.env),
                 ],
-                (false).into_val(&setup.env)
+                ("disabled").into_val(&setup.env)
             )
         ]
     );

--- a/contracts/liquidity-pool/src/testutils.rs
+++ b/contracts/liquidity-pool/src/testutils.rs
@@ -5,6 +5,7 @@ use crate::storage::{
     has_borrower, has_lender, read_admin, read_borrower, read_contract_balance, read_contributions,
     read_lender, read_loans, read_token,
 };
+use crate::types::LenderStatus;
 use crate::LiquidityPoolContractClient;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -171,10 +172,10 @@ impl LiquidityPoolContract {
         })
     }
 
-    pub fn read_lender_status(&self, lender: &Address) -> Result<bool, LPError> {
+    pub fn read_lender_status(&self, lender: &Address) -> Result<LenderStatus, LPError> {
         self.env.as_contract(&self.contract_id, || {
             let lender = read_lender(&self.env, lender)?;
-            Ok(lender.active)
+            Ok(lender.status)
         })
     }
 

--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -9,11 +9,21 @@ pub struct Loan {
     pub contributions: Map<Address, i64>,
 }
 
+#[derive(Clone, PartialEq, Debug)]
+#[contracttype]
+#[repr(u32)]
+pub enum LenderStatus {
+    Enabled,
+    Disabled,
+    PendingRemoval,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub struct Lender {
-    pub active: bool,
+    pub status: LenderStatus,
     pub balance: i128,
+    pub active_loans: u32,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### Summary

This pull request modifies the lenders' storage. We now store the status within the contract and whether the money is active in loans.

### Details

- Modified whether it was active or not by its internal status which can be enabled, disabled, or pending removal. This change is to not add another property to the contract while maintaining consistency and readability.
- Added to store a counter to know when your money is contributed to a loan, this property is necessary to be able to remove the lender, in the future, from the contract.
