### PR TITLE
feat: Add return balance to  lender before it is deleted

### DIFF
--- a/contracts/liquidity-pool/src/event.rs
+++ b/contracts/liquidity-pool/src/event.rs
@@ -1,4 +1,13 @@
+use crate::types::LenderStatus;
 use soroban_sdk::{Address, Env, Symbol};
+
+pub fn lender_status_to_string(status: LenderStatus) -> &'static str {
+    match status {
+        LenderStatus::Enabled => "enabled",
+        LenderStatus::Disabled => "disabled",
+        LenderStatus::PendingRemoval => "pending_removal",
+    }
+}
 
 pub(crate) fn initialize(env: &Env, admin: Address, token: Address) {
     let topics = (Symbol::new(env, "initialize"), admin, token);
@@ -46,9 +55,10 @@ pub(crate) fn add_lender(env: &Env, admin: Address, lender: Address) {
     env.events().publish(topics, ());
 }
 
-pub(crate) fn set_lender_status(env: &Env, admin: Address, lender: Address, active: bool) {
+pub(crate) fn set_lender_status(env: &Env, admin: Address, lender: Address, status: LenderStatus) {
     let topics = (Symbol::new(env, "set_lender_status"), admin, lender);
-    env.events().publish(topics, active);
+    env.events()
+        .publish(topics, lender_status_to_string(status));
 }
 
 pub(crate) fn remove_lender(env: &Env, admin: Address, lender: Address) {

--- a/contracts/liquidity-pool/src/lib.rs
+++ b/contracts/liquidity-pool/src/lib.rs
@@ -258,21 +258,35 @@ impl LiquidityPoolTrait for LiquidityPoolContract {
         let admin = read_admin(&env)?;
         let total_fees = calculate_fees(&env, &loan);
         let admin_fees = total_fees / 10;
-        let amount_for_lenders = amount - admin_fees;
+        let mut amount_for_lenders = amount - admin_fees;
 
         token_transfer(&env, &borrower, &env.current_contract_address(), &amount)?;
         token_transfer(&env, &env.current_contract_address(), &admin, &admin_fees)?;
+
+        let mut total_balance = read_contract_balance(&env);
 
         for (address, percentage) in loan.contributions.iter() {
             let mut lender = read_lender(&env, &address)?;
             lender.active_loans -= 1;
             lender.balance += calculate_repayment_amount(amount_for_lenders, percentage);
-            write_lender(&env, &address, &lender);
+
+            if lender.active_loans == 0 && lender.status == LenderStatus::PendingRemoval {
+                token_transfer(
+                    &env,
+                    &env.current_contract_address(),
+                    &address,
+                    &lender.balance,
+                )?;
+
+                amount_for_lenders -= lender.balance;
+                remove_lender(&env, &address);
+            } else {
+                write_lender(&env, &address, &lender);
+            }
         }
 
         let repay_loan_amount = loan.amount + calculate_fees(&env, &loan);
-        let mut total_balance = read_contract_balance(&env);
-        total_balance += amount;
+        total_balance += amount_for_lenders;
 
         if (repay_loan_amount - amount) > 0 {
             loan.amount = repay_loan_amount - amount;
@@ -396,17 +410,40 @@ impl LiquidityPoolTrait for LiquidityPoolContract {
         Ok(())
     }
 
-    fn remove_lender(env: Env, lender: Address) -> Result<(), LPError> {
+    fn remove_lender(env: Env, address: Address) -> Result<(), LPError> {
         let admin = check_admin(&env)?;
 
-        if !has_lender(&env, &lender) {
+        if !has_lender(&env, &address) {
             return Err(LPError::LenderNotRegistered);
         }
 
-        remove_lender(&env, &lender);
-        remove_lender_contribution(&env, &lender)?;
+        let mut total_balance = read_contract_balance(&env);
+        let mut lender = read_lender(&env, &address)?;
 
-        event::remove_lender(&env, admin, lender);
+        if lender.balance > total_balance {
+            return Err(LPError::BalanceNotAvailableForAmountRequested);
+        }
+
+        token_transfer(
+            &env,
+            &env.current_contract_address(),
+            &address,
+            &lender.balance,
+        )?;
+
+        total_balance -= lender.balance;
+
+        if lender.active_loans > 0 {
+            lender.status = LenderStatus::PendingRemoval;
+            write_lender(&env, &address, &lender);
+        } else {
+            remove_lender(&env, &address);
+        }
+
+        write_contract_balance(&env, &total_balance);
+        remove_lender_contribution(&env, &address)?;
+
+        event::remove_lender(&env, admin, address);
         Ok(())
     }
 }

--- a/contracts/liquidity-pool/src/percentage.rs
+++ b/contracts/liquidity-pool/src/percentage.rs
@@ -2,6 +2,7 @@ use soroban_sdk::{Address, Env, Map, Vec};
 
 use crate::errors::LPError;
 use crate::storage::read_lender;
+use crate::types::LenderStatus;
 
 type ContributionsMap = Map<Address, i64>;
 type LenderAmountMap = Map<Address, i128>;
@@ -37,7 +38,7 @@ pub fn process_lender_contribution(
     for address in contributions.iter() {
         let lender = read_lender(env, &address)?;
 
-        if lender.active {
+        if lender.status == LenderStatus::Enabled {
             let percentage = calculate_percentage(&lender.balance, total_balance);
             let new_lender_amount =
                 calculate_new_lender_amount(loan_amount, &lender.balance, percentage);

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -2,6 +2,7 @@
 extern crate std;
 
 use super::testutils::{create_token_contract, set_timestamp_for_20_days, Setup};
+use crate::types::LenderStatus;
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
     vec, Address, Env, IntoVal, Symbol,
@@ -1715,7 +1716,10 @@ fn test_set_lender_status() {
         .client()
         .set_lender_status(&lender, &false);
 
-    assert_eq!(setup.liquid_contract.read_lender_status(&lender), Ok(false));
+    assert_eq!(
+        setup.liquid_contract.read_lender_status(&lender),
+        Ok(LenderStatus::Disabled)
+    );
     let contract_events = setup.liquid_contract.get_contract_events();
 
     assert_eq!(
@@ -1750,7 +1754,7 @@ fn test_set_lender_status() {
                     setup.admin.into_val(&setup.env),
                     lender.into_val(&setup.env),
                 ],
-                (false).into_val(&setup.env)
+                ("disabled").into_val(&setup.env)
             )
         ]
     );

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -2039,7 +2039,10 @@ fn test_remove_lender_with_pending_status() {
         .client()
         .deposit(&lender_address, &10i128);
 
-    setup.liquid_contract.client().add_borrower(&borrower);
+    setup
+        .liquid_contract
+        .client()
+        .add_borrower(&borrower, &0i128, &10i128);
 
     let loan_id = setup.liquid_contract.client().loan(&borrower, &5i128);
 
@@ -2096,7 +2099,7 @@ fn test_remove_lender_with_pending_status() {
                     setup.admin.into_val(&setup.env),
                     borrower.into_val(&setup.env),
                 ],
-                ().into_val(&setup.env)
+                (0i128, 10i128).into_val(&setup.env)
             ),
             (
                 setup.liquid_contract_id.clone(),
@@ -2141,7 +2144,10 @@ fn test_remove_lender_with_repay_loan() {
         .client()
         .deposit(&lender_address, &10i128);
 
-    setup.liquid_contract.client().add_borrower(&borrower);
+    setup
+        .liquid_contract
+        .client()
+        .add_borrower(&borrower, &0i128, &10i128);
 
     let loan_id = setup.liquid_contract.client().loan(&borrower, &5i128);
 
@@ -2207,7 +2213,7 @@ fn test_remove_lender_with_repay_loan() {
                     setup.admin.into_val(&setup.env),
                     borrower.into_val(&setup.env),
                 ],
-                ().into_val(&setup.env)
+                (0i128, 10i128).into_val(&setup.env)
             ),
             (
                 setup.liquid_contract_id.clone(),

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -817,7 +817,7 @@ fn test_repay_loan_with_repayment_total_amount() {
 
     let contract_events = setup.liquid_contract.get_contract_events();
 
-    assert_eq!(setup.liquid_contract.read_contract_balance(), 10020i128);
+    assert_eq!(setup.liquid_contract.read_contract_balance(), 10018i128);
     assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(5009i128));
     assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(5009i128));
     assert!(!setup.liquid_contract.has_loan(&borrower, loan_id));
@@ -1654,6 +1654,229 @@ fn test_remove_lender() {
                     lender.into_val(&setup.env),
                 ],
                 ().into_val(&setup.env)
+            )
+        ]
+    );
+}
+
+#[test]
+fn test_remove_lender_with_pending_status() {
+    let setup = Setup::new();
+    let lender_address = Address::generate(&setup.env);
+    let borrower = Address::generate(&setup.env);
+
+    setup.env.mock_all_auths();
+
+    setup.liquid_contract.client().add_lender(&lender_address);
+    assert!(setup.liquid_contract.has_lender(&lender_address));
+
+    setup.token_admin.mint(&lender_address, &10i128);
+    setup.token_admin.mint(&setup.liquid_contract_id, &10i128);
+
+    setup
+        .liquid_contract
+        .client()
+        .deposit(&lender_address, &10i128);
+
+    setup.liquid_contract.client().add_borrower(&borrower);
+
+    let loan_id = setup.liquid_contract.client().loan(&borrower, &5i128);
+
+    assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
+
+    setup
+        .liquid_contract
+        .client()
+        .remove_lender(&lender_address);
+
+    assert_eq!(
+        setup.liquid_contract.read_lender_status(&lender_address),
+        Ok(LenderStatus::PendingRemoval)
+    );
+    let contract_events = setup.liquid_contract.get_contract_events();
+    assert_eq!(
+        contract_events,
+        vec![
+            &setup.env,
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "initialize").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    setup.token.address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "add_lender").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    lender_address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "deposit").as_val(),
+                    lender_address.into_val(&setup.env),
+                ],
+                10i128.into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "add_borrower").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    borrower.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "loan").as_val(),
+                    borrower.into_val(&setup.env),
+                    loan_id.into_val(&setup.env),
+                ],
+                5i128.into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "remove_lender").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    lender_address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            )
+        ]
+    );
+}
+
+#[test]
+fn test_remove_lender_with_repay_loan() {
+    let setup = Setup::new();
+    let lender_address = Address::generate(&setup.env);
+    let borrower = Address::generate(&setup.env);
+
+    setup.env.mock_all_auths();
+
+    setup.liquid_contract.client().add_lender(&lender_address);
+    assert!(setup.liquid_contract.has_lender(&lender_address));
+
+    setup.token_admin.mint(&lender_address, &10i128);
+    setup.token_admin.mint(&setup.liquid_contract_id, &10i128);
+
+    setup
+        .liquid_contract
+        .client()
+        .deposit(&lender_address, &10i128);
+
+    setup.liquid_contract.client().add_borrower(&borrower);
+
+    let loan_id = setup.liquid_contract.client().loan(&borrower, &5i128);
+
+    assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
+
+    setup
+        .liquid_contract
+        .client()
+        .remove_lender(&lender_address);
+
+    assert_eq!(
+        setup.liquid_contract.read_lender_status(&lender_address),
+        Ok(LenderStatus::PendingRemoval)
+    );
+
+    setup.token_admin.mint(&borrower, &5i128);
+    setup
+        .liquid_contract
+        .client()
+        .repay_loan(&borrower, &loan_id, &5i128);
+
+    assert!(!setup.liquid_contract.has_lender(&lender_address));
+
+    let contract_events = setup.liquid_contract.get_contract_events();
+    assert_eq!(
+        contract_events,
+        vec![
+            &setup.env,
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "initialize").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    setup.token.address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "add_lender").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    lender_address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "deposit").as_val(),
+                    lender_address.into_val(&setup.env),
+                ],
+                10i128.into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "add_borrower").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    borrower.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "loan").as_val(),
+                    borrower.into_val(&setup.env),
+                    loan_id.into_val(&setup.env),
+                ],
+                5i128.into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "remove_lender").as_val(),
+                    setup.admin.into_val(&setup.env),
+                    lender_address.into_val(&setup.env),
+                ],
+                ().into_val(&setup.env)
+            ),
+            (
+                setup.liquid_contract_id.clone(),
+                vec![
+                    &setup.env,
+                    *Symbol::new(&setup.env, "repay_loan").as_val(),
+                    borrower.into_val(&setup.env),
+                    loan_id.into_val(&setup.env),
+                ],
+                5i128.into_val(&setup.env)
             )
         ]
     );

--- a/contracts/liquidity-pool/src/testutils.rs
+++ b/contracts/liquidity-pool/src/testutils.rs
@@ -5,6 +5,7 @@ use crate::storage::{
     has_borrower, has_lender, read_admin, read_borrower, read_contract_balance, read_contributions,
     read_lender, read_loans, read_token,
 };
+use crate::types::LenderStatus;
 use crate::LiquidityPoolContractClient;
 use soroban_sdk::{
     testutils::{Address as _, Events, Ledger},
@@ -171,10 +172,10 @@ impl LiquidityPoolContract {
         })
     }
 
-    pub fn read_lender_status(&self, lender: &Address) -> Result<bool, LPError> {
+    pub fn read_lender_status(&self, lender: &Address) -> Result<LenderStatus, LPError> {
         self.env.as_contract(&self.contract_id, || {
             let lender = read_lender(&self.env, lender)?;
-            Ok(lender.active)
+            Ok(lender.status)
         })
     }
 

--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -9,11 +9,21 @@ pub struct Loan {
     pub contributions: Map<Address, i64>,
 }
 
+#[derive(Clone, PartialEq, Debug)]
+#[contracttype]
+#[repr(u32)]
+pub enum LenderStatus {
+    Enabled,
+    Disabled,
+    PendingRemoval,
+}
+
 #[derive(Clone)]
 #[contracttype]
 pub struct Lender {
-    pub active: bool,
+    pub status: LenderStatus,
     pub balance: i128,
+    pub active_loans: u32,
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### Summary

This pull request adds the balance of the contract back to the lender before it is deleted.

### Details

- The `remove_lender` function evaluates if all the money was returned to the lender. If there is no money contributed, it is removed, otherwise its status becomes pending removal.
- The `repay_loan` function evaluates the condition of the lender when returning his money, if it is the last loan where he contributed and his status is pending deletion, the money is returned and he is removed from the contract.

