### PR TITLE
feat: Change loan storage by id and address

### DIFF
--- a/contracts/liquidity-pool/src/storage.rs
+++ b/contracts/liquidity-pool/src/storage.rs
@@ -55,11 +55,11 @@ pub fn read_contributions(env: &Env) -> Vec<Address> {
         .unwrap_or(Vec::new(env))
 }
 
-pub fn read_loans(env: &Env, borrower: &Address) -> Vec<Loan> {
+pub fn read_loan(env: &Env, address: &Address, loan_id: &u64) -> Result<Loan, LPError> {
     env.storage()
         .persistent()
-        .get(&DataKey::Loan(borrower.clone()))
-        .unwrap_or(Vec::new(env))
+        .get(&DataKey::Loan(*loan_id, address.clone()))
+        .ok_or(LPError::LoanNotFoundOrExists)
 }
 
 pub fn read_lender(env: &Env, lender: &Address) -> Result<Lender, LPError> {
@@ -80,6 +80,12 @@ pub fn remove_borrower(env: &Env, borrower: &Address) {
     env.storage()
         .persistent()
         .remove(&DataKey::Borrower(borrower.clone()))
+}
+
+pub fn remove_loan(env: &Env, address: &Address, loan_id: &u64) {
+    env.storage()
+        .persistent()
+        .remove(&DataKey::Loan(*loan_id, address.clone()));
 }
 
 pub fn remove_lender(env: &Env, lender: &Address) {
@@ -118,10 +124,10 @@ pub fn write_contract_balance(env: &Env, amount: &i128) {
         .set(&DataKey::TotalBalance, amount);
 }
 
-pub fn write_loans(env: &Env, borrower: &Address, loans: &Vec<Loan>) {
+pub fn write_loan(env: &Env, address: &Address, loan_id: &u64, loan: &Loan) {
     env.storage()
         .persistent()
-        .set(&DataKey::Loan(borrower.clone()), loans);
+        .set(&DataKey::Loan(*loan_id, address.clone()), loan);
 }
 
 pub fn write_lender(env: &Env, lender: &Address, data: &Lender) {

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -1034,7 +1034,7 @@ fn test_repay_loan_without_repayment_total_amount() {
     assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
     assert_eq!(
         setup.liquid_contract.read_loan_amount(&borrower, loan_id),
-        2i128
+        Ok(2i128)
     );
 
     assert_eq!(

--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -3,7 +3,6 @@ use soroban_sdk::{contracttype, Address, Map};
 #[derive(Clone)]
 #[contracttype]
 pub struct Loan {
-    pub id: u64,
     pub amount: i128,
     pub start_time: u64,
     pub contributions: Map<Address, i64>,
@@ -33,5 +32,5 @@ pub enum DataKey {
     Contribution,
     Borrower(Address),
     Lender(Address),
-    Loan(Address),
+    Loan(u64, Address),
 }


### PR DESCRIPTION
### Summary

This pull request modifies the storage of the loans. Previously we stored them by addres and now by address and ID.

### Details

- This change is to follow best storage practices and to save on storage costs for the loans.
