### PR TITLE
feat: Add a vault in the storage to transfer when generate fees

### DIFF
--- a/contracts/liquidity-pool-deployer/src/lib.rs
+++ b/contracts/liquidity-pool-deployer/src/lib.rs
@@ -13,7 +13,13 @@ pub struct LiquidityPoolDeployer;
 
 #[contractimpl]
 impl LiquidityPoolDeployer {
-    pub fn deploy(env: Env, admin: Address, salt: BytesN<32>, token: Address) -> (Address, Val) {
+    pub fn deploy(
+        env: Env,
+        admin: Address,
+        salt: BytesN<32>,
+        token: Address,
+        vault: Address,
+    ) -> (Address, Val) {
         if admin != env.current_contract_address() {
             admin.require_auth();
         }
@@ -22,7 +28,7 @@ impl LiquidityPoolDeployer {
 
         let deployed_address = env.deployer().with_current_contract(salt).deploy(wasm_hash);
 
-        let init_args = (admin, token).into_val(&env);
+        let init_args = (admin, token, vault).into_val(&env);
 
         let contract: Val = env.invoke_contract(
             &deployed_address,

--- a/contracts/liquidity-pool-deployer/src/test.rs
+++ b/contracts/liquidity-pool-deployer/src/test.rs
@@ -29,11 +29,12 @@ fn test_deploy_from_contract() {
     let salt = BytesN::from_array(&env, &[0; 32]);
     let admin = Address::generate(&env);
     let token_admin = Address::generate(&env);
+    let vault = Address::generate(&env);
 
     let (token, _token_client) = create_token_contract(&env, &token_admin);
 
     env.mock_all_auths();
-    let (contract_id, _contract) = deployer_client.deploy(&admin, &salt, &token.address);
+    let (contract_id, _contract) = deployer_client.deploy(&admin, &salt, &token.address, &vault);
 
     let client = liquidity_pool::Client::new(&env, &contract_id);
     let total_balance = client.balance(&admin);

--- a/contracts/liquidity-pool/src/errors.rs
+++ b/contracts/liquidity-pool/src/errors.rs
@@ -23,4 +23,5 @@ pub enum LPError {
     BorrowerNotFound = 17,
     BorrowerDisabled = 18,
     LoanAmountOutsideWithdrawalLimits = 19,
+    VaultNotFound = 20,
 }

--- a/contracts/liquidity-pool/src/event.rs
+++ b/contracts/liquidity-pool/src/event.rs
@@ -9,8 +9,8 @@ pub fn lender_status_to_string(status: LenderStatus) -> &'static str {
     }
 }
 
-pub(crate) fn initialize(env: &Env, admin: Address, token: Address) {
-    let topics = (Symbol::new(env, "initialize"), admin, token);
+pub(crate) fn initialize(env: &Env, admin: Address, token: Address, vault: Address) {
+    let topics = (Symbol::new(env, "initialize"), admin, token, vault);
     env.events().publish(topics, ());
 }
 

--- a/contracts/liquidity-pool/src/interface.rs
+++ b/contracts/liquidity-pool/src/interface.rs
@@ -2,7 +2,7 @@ use crate::errors::LPError;
 use soroban_sdk::{Address, Env};
 
 pub trait LiquidityPoolTrait {
-    fn initialize(env: Env, admin: Address, token: Address) -> Result<(), LPError>;
+    fn initialize(env: Env, admin: Address, token: Address, vault: Address) -> Result<(), LPError>;
 
     fn balance(env: Env, lender: Address) -> Result<i128, LPError>;
 

--- a/contracts/liquidity-pool/src/storage.rs
+++ b/contracts/liquidity-pool/src/storage.rs
@@ -76,6 +76,13 @@ pub fn read_token(env: &Env) -> Result<Address, LPError> {
     }
 }
 
+pub fn read_vault(env: &Env) -> Result<Address, LPError> {
+    match env.storage().persistent().get(&DataKey::Vault) {
+        Some(vault) => Ok(vault),
+        None => Err(LPError::VaultNotFound),
+    }
+}
+
 pub fn remove_borrower(env: &Env, borrower: &Address) {
     env.storage()
         .persistent()
@@ -144,4 +151,8 @@ pub fn write_lender_contribution(env: &Env, contributions: Vec<Address>) {
 
 pub fn write_token(env: &Env, address: &Address) {
     env.storage().persistent().set(&DataKey::Token, address);
+}
+
+pub fn write_vault(env: &Env, address: &Address) {
+    env.storage().persistent().set(&DataKey::Vault, address);
 }

--- a/contracts/liquidity-pool/src/test.rs
+++ b/contracts/liquidity-pool/src/test.rs
@@ -19,6 +19,7 @@ fn test_initialize() {
         setup.liquid_contract.read_token(),
         Ok(setup.token.address.clone())
     );
+    assert_eq!(setup.liquid_contract.read_vault(), Ok(setup.vault.clone()));
     assert_eq!(
         contract_events,
         vec![
@@ -30,6 +31,7 @@ fn test_initialize() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             )
@@ -44,13 +46,14 @@ fn test_already_initialize() {
 
     let env = Env::default();
     let admin = Address::generate(&env);
+    let vault = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let (token, _token_client) = create_token_contract(&env, &token_admin);
 
     setup
         .liquid_contract
         .client()
-        .initialize(&admin, &token.address);
+        .initialize(&admin, &token.address, &vault);
 }
 
 #[test]
@@ -143,6 +146,7 @@ fn test_deposit() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -308,6 +312,7 @@ fn test_withdraw() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -544,6 +549,7 @@ fn test_loan() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -763,6 +769,7 @@ fn test_request_two_loans() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -855,6 +862,7 @@ fn test_repay_loan_with_repayment_total_amount() {
     assert!(setup.liquid_contract.has_loan(&borrower, loan_id));
     assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(0i128));
     assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(0i128));
+    let vault_balance_after_repay_loan = setup.token.balance(&setup.vault);
 
     set_timestamp_for_20_days(&setup.env);
 
@@ -871,6 +879,7 @@ fn test_repay_loan_with_repayment_total_amount() {
     assert_eq!(setup.liquid_contract.read_lender(&lender1), Ok(5009i128));
     assert_eq!(setup.liquid_contract.read_lender(&lender2), Ok(5009i128));
     assert!(!setup.liquid_contract.has_loan(&borrower, loan_id));
+    assert!(vault_balance_after_repay_loan < setup.token.balance(&setup.vault));
     assert_eq!(
         contract_events,
         vec![
@@ -882,6 +891,7 @@ fn test_repay_loan_with_repayment_total_amount() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1049,6 +1059,7 @@ fn test_repay_loan_without_repayment_total_amount() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1365,6 +1376,7 @@ fn test_add_borrower() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1483,6 +1495,7 @@ fn test_set_borrower_status() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1589,6 +1602,7 @@ fn test_set_borrower_limits() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1652,6 +1666,7 @@ fn test_set_borrower_limits_when_min_greater_than_max() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1789,6 +1804,7 @@ fn test_remove_borrower() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1892,6 +1908,7 @@ fn test_add_lender() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -1993,6 +2010,7 @@ fn test_remove_lender() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -2069,6 +2087,7 @@ fn test_remove_lender_with_pending_status() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -2183,6 +2202,7 @@ fn test_remove_lender_with_repay_loan() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),
@@ -2323,6 +2343,7 @@ fn test_set_lender_status() {
                     *Symbol::new(&setup.env, "initialize").as_val(),
                     setup.admin.into_val(&setup.env),
                     setup.token.address.into_val(&setup.env),
+                    setup.vault.into_val(&setup.env)
                 ],
                 ().into_val(&setup.env)
             ),

--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -40,6 +40,7 @@ pub enum DataKey {
     Token,
     Admin,
     Contribution,
+    Vault,
     Borrower(Address),
     Lender(Address),
     Loan(u64, Address),


### PR DESCRIPTION
### Summary

This pull request adds an address to the storage that functions as the company's vault. This change is to avoid sending the generated fees to the admin to improve the security of the contract.

### Details

- Add a vault in the storage to transfer the fees generated by repaying a loan.
- The `initialize` function receives the vault as a parameter and stores it in the contract.
- The `Deployer Contract` now receives the vault as a parameter to initialize the `Clear Liquidity Pool` contract.

