### PR TITLE
feat: Update the return of the deploy function and the initialize file

### DIFF
--- a/contracts/liquidity-pool-deployer/src/lib.rs
+++ b/contracts/liquidity-pool-deployer/src/lib.rs
@@ -19,7 +19,7 @@ impl LiquidityPoolDeployer {
         salt: BytesN<32>,
         token: Address,
         vault: Address,
-    ) -> (Address, Val) {
+    ) -> Address {
         if admin != env.current_contract_address() {
             admin.require_auth();
         }
@@ -30,13 +30,13 @@ impl LiquidityPoolDeployer {
 
         let init_args = (admin, token, vault).into_val(&env);
 
-        let contract: Val = env.invoke_contract(
+        let _contract: Val = env.invoke_contract(
             &deployed_address,
             &Symbol::new(&env, "initialize"),
             init_args,
         );
 
-        (deployed_address, contract)
+        deployed_address
     }
 }
 

--- a/contracts/liquidity-pool-deployer/src/test.rs
+++ b/contracts/liquidity-pool-deployer/src/test.rs
@@ -34,7 +34,7 @@ fn test_deploy_from_contract() {
     let (token, _token_client) = create_token_contract(&env, &token_admin);
 
     env.mock_all_auths();
-    let (contract_id, _contract) = deployer_client.deploy(&admin, &salt, &token.address, &vault);
+    let contract_id = deployer_client.deploy(&admin, &salt, &token.address, &vault);
 
     let client = liquidity_pool::Client::new(&env, &contract_id);
     let total_balance = client.balance(&admin);

--- a/initialize.sh
+++ b/initialize.sh
@@ -7,7 +7,7 @@ NETWORK="$1"
 WASM_PATH="target/wasm32-unknown-unknown/release/"
 CLEAR_WASM=$WASM_PATH"liquidity_pool"
 DEPLOYER_WASM=$WASM_PATH"liquidity_pool_deployer"
-TOKEN_NATIVE_ID="CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
+TOKEN_ID="CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 
 case "$1" in
 standalone)
@@ -68,4 +68,25 @@ CONTRACT_DEPLOYER_ID="$(
 )"
 echo "Contract deployed successfully with ID: $CONTRACT_DEPLOYER_ID"
 
+echo Generate Vault Address
+  stellar keys generate vault --network $NETWORK
+  VAULT_ADDRESS="$(soroban keys address vault)"
+echo "Vault Address: $VAULT_ADDRESS"
+
+echo Install Clear Liquidity Pool Contract
+SALT="$(
+  stellar contract install --wasm $CLEAR_WASM".optimized.wasm" $ARGS
+)"
+
+echo Initialize Clear Liquidity Pool Contract
+CLEAR_CONTRACT="$(
+  stellar contract invoke --id $CONTRACT_DEPLOYER_ID $ARGS \
+   -- deploy \
+   --admin $CLEAR_ADMIN_ADDRESS \
+   --salt $SALT \
+   --token $TOKEN_ID \
+   --vault $VAULT_ADDRESS
+)"
+
+echo "Clear contract deployed successfully: $CLEAR_CONTRACT"
 echo "Done"


### PR DESCRIPTION
### Summary

This pull request modifies the return in the deploy function of the deployer contract and adds create and start the Clear contract in the initialize file.

### Details

- The `deploy` function returned a tuple with the value of the return to the `initialize` call along with the id of the contract. The return value is always an empty value, so the change is made.
- Update the `initialize` file. Before, it created only the deployer contract; now we add that it creates and initializes the clear contract.
