### PR TITLE
fix: Change loan storage to a map to avoid transaction errors

### DIFF
--- a/contracts/liquidity-pool/src/types.rs
+++ b/contracts/liquidity-pool/src/types.rs
@@ -43,5 +43,5 @@ pub enum DataKey {
     Vault,
     Borrower(Address),
     Lender(Address),
-    Loan(u64, Address),
+    Loan(Address),
 }


### PR DESCRIPTION
### Summary

This pull request corrects the storage of the loans by checking for errors in the transaction. 

### Details

- Previously we were storing a `Loan(u64, Address)` to be able to interact individually with each loan but it gave us errors when using a random number as key storage.
- Now we store `Loan(Address)` and store a map where the `key` is the `id` and the `value` is the `Loan`.

### Evidence

- We create a loan, verify the amount to be repaid and repay the loan.

https://github.com/user-attachments/assets/947d57e3-1dbf-4430-8dcc-3e696e460e0a

